### PR TITLE
feat: increment Flutter app build number along with its version

### DIFF
--- a/lib/versionReplacer.ts
+++ b/lib/versionReplacer.ts
@@ -47,7 +47,7 @@ export const updateK8sYaml = (
  * @throws {Error} When the old version could not be found in the pubspec.yaml file content.
  */
 export const updatePubspecVersion = (pubspecContent: string, oldVersion: string, newVersion: string): string => {
-  const regex = `version:\\s+(${oldVersion})(?:(?:\\+)(\\d))?`;
+  const regex = `version:\\s+(${oldVersion})(?:(?:\\+)(\\d+))?`;
 
   const match = pubspecContent.match(regex);
 

--- a/lib/versionReplacer.ts
+++ b/lib/versionReplacer.ts
@@ -47,7 +47,7 @@ export const updateK8sYaml = (
  * @throws {Error} When the old version could not be found in the pubspec.yaml file content.
  */
 export const updatePubspecVersion = (pubspecContent: string, oldVersion: string, newVersion: string): string => {
-  const regex = `version:\\s+(${oldVersion})`;
+  const regex = `version:\\s+(${oldVersion})(?:(?:\\+)(\\d))?`;
 
   const match = pubspecContent.match(regex);
 
@@ -55,8 +55,19 @@ export const updatePubspecVersion = (pubspecContent: string, oldVersion: string,
     throw new Error("Could not match old version in pubspec.yaml.");
   }
 
-  return pubspecContent.replace(match[0], match[0].replace(match[1], newVersion));
+  let versionString = match[0].replace(match[1], newVersion);
+
+  if (hasBuildNumber(versionString)) {
+    versionString = incrementBuildNumber(versionString, match[2]);
+  }
+
+  return pubspecContent.replace(match[0], versionString);
 };
+
+const hasBuildNumber = (versionString: string) => versionString.includes("+");
+
+const incrementBuildNumber = (versionString: string, oldBuildNumber: string) =>
+  versionString.replace(`+${oldBuildNumber}`, `+${(parseInt(oldBuildNumber) + 1).toString()}`);
 
 /**
  * Updates given replacements in XML file content.

--- a/test/versionReplacer.test.ts
+++ b/test/versionReplacer.test.ts
@@ -169,6 +169,49 @@ dev_dependencies:
         .expect(() => updatePubspecVersion(sampleContent, "0.8.0", "1.0.0"))
         .to.throw("Could not match old version in pubspec.yaml.");
     });
+    it("should increment build number if present", function () {
+      const sampleContentWithBuildNumber = `name: some-module
+      description: Some plugin for Flutter apps
+      version: 0.9.0+1
+      author: Stefan Ißmer <stefan.issmer@droidsolutions.de>
+      homepage: https://somewhere.on/line
+      
+      environment:
+        sdk: ">=2.2.0 <3.0.0"
+      
+      dependencies:
+        flutter:
+          sdk: flutter
+        http: ^0.12.0+2
+      
+      dev_dependencies:
+        flutter_test:
+          sdk: flutter
+        mockito: ^4.1.1`;
+
+      const actual = updatePubspecVersion(sampleContentWithBuildNumber, "0.9.0", "1.0.0");
+
+      const expected = `name: some-module
+      description: Some plugin for Flutter apps
+      version: 1.0.0+2
+      author: Stefan Ißmer <stefan.issmer@droidsolutions.de>
+      homepage: https://somewhere.on/line
+      
+      environment:
+        sdk: ">=2.2.0 <3.0.0"
+      
+      dependencies:
+        flutter:
+          sdk: flutter
+        http: ^0.12.0+2
+      
+      dev_dependencies:
+        flutter_test:
+          sdk: flutter
+        mockito: ^4.1.1`;
+
+      chai.expect(actual).to.equal(expected);
+    });
   });
 
   context("updateXml", function () {


### PR DESCRIPTION
For now, only version is updated in pubspec.yaml. With this code, the build number (the optional part after the plus sign of the version in the pubspec.yaml file) will also be incremented.